### PR TITLE
Add --dbfile command line argument

### DIFF
--- a/otmonitor.vfs/otmonitor.tcl
+++ b/otmonitor.vfs/otmonitor.tcl
@@ -1623,6 +1623,9 @@ getopt flag arg $argv {
     --debug {
 	set verbose 1
     }
+    --dbfile:FILE {
+  set dbfile $arg
+    }
     -h - --help {
 	# display this help and exit.
 	help

--- a/otmonitor.vfs/security.tcl
+++ b/otmonitor.vfs/security.tcl
@@ -1,9 +1,14 @@
 namespace eval security {
     package require sqlite3
     variable cache {}
-    variable authdb [file join [file dirname $starkit::topdir] auth auth.db]
-    if {![file writable $authdb]} {
-	set authdb [file join [settings appdata] auth.db]
+    variable authdb
+    if {[info exists dbfile] && [file writable [file dirname $dbfile]]} {
+        set authdb $dbfile
+    } else {
+        set authdb [file join [file dirname $starkit::topdir] auth auth.db]
+        if {![file writable $authdb]} {
+            set authdb [file join [settings appdata] auth.db]
+        }
     }
     namespace ensemble create -subcommands {
 	getusers adduser deluser chguser vfyuser addcert delcert vfycert
@@ -28,10 +33,13 @@ proc security::permissions {file str} {
 }
 
 proc security::createdb {} {
+    global dbfile
     variable authdb
-    set authdir [file dirname $authdb]
-    file mkdir $authdir
-    permissions $authdir go-rwx
+    if {![info exists dbfile]} {
+        set authdir [file dirname $authdb]
+        file mkdir $authdir
+        permissions $authdir go-rwx
+    }
     authdb {
 	create table if not exists users (
 	  name text unique,


### PR DESCRIPTION
This patch adds an option to specify the path to the SQLite file.  I have 2 boilers with 2 otmonitor daemons running and the `auth.db` was getting used by both daemons. Also my daemon user is an account without a home dir which the current logic did not seem to find a writable dir for.

for example in a systemd service file: `--dbfile /var/lib/otmonitor/auth-%i.db`