### PR TITLE
Update websocket regex in javascript code to match the full url when proxied through nginx

### DIFF
--- a/otmonitor.vfs/docroot/configure.js
+++ b/otmonitor.vfs/docroot/configure.js
@@ -18,7 +18,7 @@ function formatquery(url, json) {
     return url + '?' + query.join('&');
 }
 
-var wsurl = "ws" + document.URL.match("s?://[-a-z0-9.:]+/") + "configure.ws"
+var wsurl = "ws" + document.URL.match("s?://[-a-zA-Z0-9.:_/]+/") + "configure.ws";
 if (typeof query !== 'undefined') {
     wsurl = formatquery(wsurl, query);
 }
@@ -162,7 +162,7 @@ function input(w, section, name) {
 
 function seconds(w, section, name) {
   config(section, name, w.value * 1000);
-} 
+}
 
 function sync(w, id) {
   var e = document.getElementById(id);

--- a/otmonitor.vfs/docroot/iphone.js
+++ b/otmonitor.vfs/docroot/iphone.js
@@ -5,7 +5,7 @@ function debug(str) {
     if (output) output.innerHTML += str + "<BR>";
 }
 
-var wsurl = "ws" + document.URL.match("s?://[-a-z0-9.:]+/") + "basic.ws";
+var wsurl = "ws" + document.URL.match("s?://[-a-zA-Z0-9.:_/]+/") + "basic.ws";
 
 if ("WebSocket" in window) {
    var websocket = new WebSocket(wsurl);

--- a/otmonitor.vfs/docroot/message.js
+++ b/otmonitor.vfs/docroot/message.js
@@ -1,4 +1,4 @@
-var wsurl = "ws" + document.URL.match("s?://[-a-z0-9.:/]+/") + "message.ws"
+var wsurl = "ws" + document.URL.match("s?://[-a-zA-Z0-9.:_/]+/") + "message.ws"
 
 if ("WebSocket" in window) {
    var ws = new WebSocket(wsurl);

--- a/otmonitor.vfs/docroot/status.js
+++ b/otmonitor.vfs/docroot/status.js
@@ -18,7 +18,7 @@ function formatquery(url, json) {
     return url + '?' + query.join('&');
 }
 
-var wsurl = "ws" + document.URL.match("s?://[-a-z0-9.:]+/") + "status.ws"
+var wsurl = "ws" + document.URL.match("s?://[-a-zA-Z0-9.:_/]+/") + "status.ws"
 if (typeof query !== 'undefined') {
     wsurl = formatquery(wsurl, query);
 }
@@ -181,7 +181,7 @@ function input(w, section, name) {
 
 function seconds(w, section, name) {
     config(section, name, w.value * 1000);
-} 
+}
 
 function sync(w, id) {
     var e = document.getElementById(id);

--- a/otmonitor.vfs/docroot/upgrade.js
+++ b/otmonitor.vfs/docroot/upgrade.js
@@ -4,7 +4,7 @@ function debug(str) {
   if (output) output.innerHTML += str + "<BR>"
 }
 
-var wsurl = "ws" + document.URL.match("s?://[-a-z0-9.:]+/") + "upgrade.ws"
+var wsurl = "ws" + document.URL.match("s?://[-a-zA-Z0-9.:_/]+/") + "upgrade.ws"
 
 if ("WebSocket" in window) {
    debug("Using WebSocket")


### PR DESCRIPTION
Hello sir,

When I'm using otmonitor in the [home assistant addon](https://github.com/basnijholt/addon-otmonitor/), otmonitor is embedded in the home-assistant application. As a result all requests are proxied through nginx from an endpoint location that contains random upper and lower chars and an underscore.

The url endpoint location when proxied is for example: `$hostname/api/hassio_ingress/ERFaegsGr54tw5y4sgerga/status.html` but the websocket connections are tried to `$hostname/status.ws`. 

The regex for matching the websocket url from the page uri does not include those chars and matches only lowercase until the first `/`, which is why the ws connections errors out with a 404.

```WebSocket connection to 'wss://$hostname/status.ws?var=gui&var=error' failed: Error during WebSocket handshake: Unexpected response code: 404```

By "widening" the regex matching `A-Z_/` too, I'm trying to use up until the last `/` of the url instead of the first one, which allows connecting to the websocket even when proxied through an endpoint.